### PR TITLE
Get Ciphertext Endpoint

### DIFF
--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -180,12 +180,12 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
             .and_then(Self::create_transfer);
 
         // GET /testnet3/ciphertext/{commitment}
-        let get_ciphertext = warp::get()
-            .and(warp::path!("testnet3" / "ciphertext" / ..))
+        let get_record_ciphertext = warp::get()
+            .and(warp::path!("testnet3" / "record" / "ciphertext" / ..))
             .and(warp::path::param::<Field<N>>())
             .and(warp::path::end())
             .and(with(self.ledger.clone()))
-            .and_then(Self::get_ciphertext);
+            .and_then(Self::get_record_ciphertext);
 
         // Return the list of routes.
         latest_height
@@ -205,7 +205,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
             .or(ciphertexts_unspent)
             .or(transaction_broadcast)
             .or(create_transfer)
-            .or(get_ciphertext)
+            .or(get_record_ciphertext)
     }
 }
 
@@ -408,11 +408,11 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
     }
 
     /// Returns the record ciphertext for the given view key.
-    async fn get_ciphertext(
+    async fn get_record_ciphertext(
         commitment: Field<N>,
         ledger: Arc<RwLock<Ledger<N, B, P>>>,
     ) -> Result<impl Reply, Rejection> {
-        if let Some(record_ciphertext) = ledger.read().get_record(commitment).or_reject()? {
+        if let Some(record_ciphertext) = ledger.read().get_record_ciphertext(commitment).or_reject()? {
             Ok(reply::with_status(reply::json(&record_ciphertext), StatusCode::OK))
         } else {
             Err(warp::reject::not_found())

--- a/vm/compiler/src/ledger/get.rs
+++ b/vm/compiler/src/ledger/get.rs
@@ -62,7 +62,7 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
     }
 
     /// Returns the record for the given `commitment`.
-    pub fn get_record(&self, commitment: Field<N>) -> Result<Option<Record<N, Ciphertext<N>>>> {
+    pub fn get_record_ciphertext(&self, commitment: Field<N>) -> Result<Option<Record<N, Ciphertext<N>>>> {
         self.transitions.get_record(&commitment)
     }
 

--- a/vm/compiler/src/ledger/get.rs
+++ b/vm/compiler/src/ledger/get.rs
@@ -61,6 +61,11 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Ledger<N, B, P> {
         }
     }
 
+    /// Returns the record for the given `commitment`.
+    pub fn get_record(&self, commitment: Field<N>) -> Result<Option<Record<N, Ciphertext<N>>>> {
+        self.transitions.get_record(&commitment)
+    }
+
     /// Returns the block transactions for the given block height.
     pub fn get_transactions(&self, height: u32) -> Result<Transactions<N>> {
         // Retrieve the block hash.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This endpoint will be consumed in the `aleo execute` command workflow. The idea is for this command to be able to get the record to consume in a program execution out of the Record Commitment with the help of the user's View Key.

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->
