### PR TITLE
Update Package Deployment

### DIFF
--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -169,8 +169,6 @@ impl<N: Network> Package<N> {
 
         let deployment_transaction = Transaction::from_deployment(deployment, additional_fee)?;
 
-        serde_json::to_writer(std::fs::File::create("deployment_transaction.json")?, &deployment_transaction)?;
-
         match endpoint {
             Some(ref endpoint) => {
                 // Construct the deploy request.

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -164,9 +164,9 @@ impl<N: Network> Package<N> {
         let rng = &mut rand::thread_rng();
         // Compute the deployment.
         let deployment = process.deploy::<A, _>(program, rng)?;
-
+        // Compute the additional fee.
         let (_, additional_fee) = process.execute_additional_fee::<A, _>(private_key, credits, 1, rng)?;
-
+        // Compute the deployment transaction.
         let deployment_transaction = Transaction::from_deployment(deployment, additional_fee)?;
 
         match endpoint {

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -182,50 +182,59 @@ impl<N: Network> Package<N> {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     type CurrentNetwork = snarkvm_console::network::Testnet3;
-//     type CurrentAleo = snarkvm_circuit::network::AleoV0;
+    type CurrentNetwork = snarkvm_console::network::Testnet3;
+    type CurrentAleo = snarkvm_circuit::network::AleoV0;
 
-//     #[test]
-//     fn test_deploy() {
-//         // Samples a new package at a temporary directory.
-//         let (directory, package) = crate::package::test_helpers::sample_package();
+    #[test]
+    fn test_deploy() {
+        let (directory, package) = crate::package::test_helpers::sample_package();
+        let private_key = package.manifest_file().development_private_key();
+        let address = Address::try_from(private_key).unwrap();
+        let record = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::from_str(&format!(
+            "{{ owner: {address}.private, gates: 5u64.private, _nonce: 0group.public }}"
+        ))
+        .unwrap();
 
-//         // Deploy the package.
-//         let deployment_transaction = package.deploy::<CurrentAleo>(None).unwrap();
-//         if let Transaction::Deploy(_, deployment, _) = deployment_transaction {
-//             // Ensure the deployment edition matches.
-//             assert_eq!(<CurrentNetwork as Network>::EDITION, deployment.edition());
-//             // Ensure the deployment program ID matches.
-//             assert_eq!(package.program().id(), deployment.program_id());
-//             // Ensure the deployment program matches.
-//             assert_eq!(package.program(), deployment.program());
-//         }
+        // Deploy the package.
+        let deployment_transaction = package.deploy::<CurrentAleo>(None, private_key, record).unwrap();
+        if let Transaction::Deploy(_, deployment, _) = deployment_transaction {
+            // Ensure the deployment edition matches.
+            assert_eq!(<CurrentNetwork as Network>::EDITION, deployment.edition());
+            // Ensure the deployment program ID matches.
+            assert_eq!(package.program().id(), deployment.program_id());
+            // Ensure the deployment program matches.
+            assert_eq!(package.program(), deployment.program());
+        }
 
-//         // Proactively remove the temporary directory (to conserve space).
-//         std::fs::remove_dir_all(directory).unwrap();
-//     }
+        // Proactively remove the temporary directory (to conserve space).
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 
-//     #[test]
-//     fn test_deploy_with_import() {
-//         // Samples a new package at a temporary directory.
-//         let (directory, package) = crate::package::test_helpers::sample_package_with_import();
+    #[test]
+    fn test_deploy_with_import() {
+        let (directory, package) = crate::package::test_helpers::sample_package_with_import();
+        let private_key = package.manifest_file().development_private_key();
+        let address = Address::try_from(private_key).unwrap();
+        let record = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::from_str(&format!(
+            "{{ owner: {address}.private, gates: 5u64.private, _nonce: 0group.public }}"
+        ))
+        .unwrap();
 
-//         // Deploy the package.
-//         let deployment_transaction = package.deploy::<CurrentAleo>(None).unwrap();
-//         if let Transaction::Deploy(_, deployment, _) = deployment_transaction {
-//             // Ensure the deployment edition matches.
-//             assert_eq!(<CurrentNetwork as Network>::EDITION, deployment.edition());
-//             // Ensure the deployment program ID matches.
-//             assert_eq!(package.program().id(), deployment.program_id());
-//             // Ensure the deployment program matches.
-//             assert_eq!(package.program(), deployment.program());
-//         }
+        let deployment_transaction = package.deploy::<CurrentAleo>(None, private_key, record).unwrap();
+        if let Transaction::Deploy(_, deployment, _) = deployment_transaction {
+            // Ensure the deployment edition matches.
+            assert_eq!(<CurrentNetwork as Network>::EDITION, deployment.edition());
+            // Ensure the deployment program ID matches.
+            assert_eq!(package.program().id(), deployment.program_id());
+            // Ensure the deployment program matches.
+            assert_eq!(package.program(), deployment.program());
+        }
 
-//         // Proactively remove the temporary directory (to conserve space).
-//         std::fs::remove_dir_all(directory).unwrap();
-//     }
-// }
+        // Proactively remove the temporary directory (to conserve space).
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/vm/package/deploy.rs
+++ b/vm/package/deploy.rs
@@ -31,7 +31,10 @@ pub struct DeployRequest<N: Network> {
 impl<N: Network> DeployRequest<N> {
     /// Sends the request to the given endpoint.
     pub fn new(transaction: Transaction<N>, address: Address<N>, program_id: ProgramID<N>) -> Result<Self> {
-        ensure!(matches!(transaction, Transaction::Deploy(_, _, _)));
+        ensure!(
+            matches!(transaction, Transaction::Deploy(_, _, _)),
+            "Cannot create a deploy request with an execution transaction"
+        );
         Ok(Self { transaction, address, program_id })
     }
 
@@ -98,7 +101,10 @@ pub struct DeployResponse<N: Network> {
 impl<N: Network> DeployResponse<N> {
     /// Initializes a new deploy response.
     pub fn new(transaction: Transaction<N>) -> Result<Self> {
-        ensure!(matches!(transaction, Transaction::Deploy(_, _, _)));
+        ensure!(
+            matches!(transaction, Transaction::Deploy(_, _, _)),
+            "Cannot create a deploy response with an execution transaction"
+        );
         Ok(Self { transaction })
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

- `DeploymentRequest` should contain a deployment transaction instead of a deployment because the client should be responsible for executing the transaction that involves the additional fee execution and then broadcast it.
- `DeploymentResponse` should contain the same deployment transaction that was sent in the `DeploymentRequest`.
- In order to execute the deployment transaction the client must provide the private key and an unspent record.

## Test Plan

<!--
    If you changed any code, please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

The tests were updated.

## Related PRs

<!--
    If this PR adds or changes functionality, please take some time to
    update the docs at https://github.com/AleoHQ/snarkVM, and link to your PR here.
-->

