### PR TITLE
Fix endpoint methods

### DIFF
--- a/rest/src/routes.rs
+++ b/rest/src/routes.rs
@@ -131,23 +131,23 @@ impl<N: Network, B: BlockStorage<N>, P: ProgramStorage<N>> Server<N, B, P> {
             .and(with(self.ledger.clone()))
             .and_then(Self::get_state_path);
 
-        // GET /testnet3/records/all
-        let records_all = warp::get()
+        // POST /testnet3/records/all
+        let records_all = warp::post()
             .and(warp::path!("testnet3" / "records" / "all"))
             .and(warp::body::content_length_limit(128))
             .and(warp::body::json())
             .and(with(self.ledger.clone()))
             .and_then(Self::records_all);
 
-        // GET /testnet3/records/spent
-        let records_spent = warp::get()
+        // POST /testnet3/records/spent
+        let records_spent = warp::post()
             .and(warp::path!("testnet3" / "records" / "spent"))
             .and(warp::body::content_length_limit(128))
             .and(warp::body::json())
             .and(with(self.ledger.clone()))
             .and_then(Self::records_spent);
 
-        // GET /testnet3/records/unspent
+        // POST /testnet3/records/unspent
         let records_unspent = warp::post()
             .and(warp::path!("testnet3" / "records" / "unspent"))
             .and(warp::body::content_length_limit(128))


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

The methods declared for the endpoints `testnet3/records/all` and `testnet3/records/spent` were wrong, to use them the request method should be a `POST`
